### PR TITLE
detect and disable debugger, rather than adding a noop DB::DB

### DIFF
--- a/lib/Devel/JSON.pm
+++ b/lib/Devel/JSON.pm
@@ -1,12 +1,15 @@
+package Devel::JSON;
+BEGIN {
+    # detect -d:JSON.  debugger features aren't needed, so disable them for speed.
+    if (!defined &DB::DB && $^P & 0x02) {
+        $^P = 0;
+    }
+}
+
 use strict;
 use warnings;
 
-package Devel::JSON;
-
 our $VERSION = '1.001';
-
-# Just to allow to be loaded with -d:JSON
-sub DB::DB {}
 
 use JSON::MaybeXS ();
 


### PR DESCRIPTION
When used as -d:JSON, debugger features will be enabled.  This requires
a DB::DB sub exist, and slows down many parts of perl.  Instead, we can
detect that we have been used in this way, and disable the debugger
features.  This also allows the module to be used with perl5db like
perl -d -MDevel::JSON -e'...' since we are not installing a noop DB::DB.

The code is intentionally placed before strict and warnings are enabled,
so that the debug flags are disabled by the time they are loaded and
used.